### PR TITLE
only cp apidocs if api is generated

### DIFF
--- a/buildScripts/release.groovy
+++ b/buildScripts/release.groovy
@@ -26,9 +26,10 @@ pipeline {
         }
         stage("Copy Specs") {
             steps {
-                sh "[ -d "api" ] && mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
+                sh "mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}"
                 sh "cp -r spec/target/generated-docs/* /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}"
-                sh "[ -d "api" ] && cp -r api/target/apidocs/* /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
+                sh "[ -d 'api' ] && mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
+                sh "[ -d 'api' ] && cp -r api/target/apidocs/* /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
             }
         }
     }

--- a/buildScripts/release.groovy
+++ b/buildScripts/release.groovy
@@ -28,8 +28,12 @@ pipeline {
             steps {
                 sh "mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}"
                 sh "cp -r spec/target/generated-docs/* /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}"
-                sh "[ -d 'api' ] && mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
-                sh "[ -d 'api' ] && cp -r api/target/apidocs/* /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
+                script {
+                    if (fileExists('api')) {
+                        sh "mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
+                        sh "cp -r api/target/apidocs/* /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
+                    }
+                }
             }
         }
     }

--- a/buildScripts/release.groovy
+++ b/buildScripts/release.groovy
@@ -26,9 +26,9 @@ pipeline {
         }
         stage("Copy Specs") {
             steps {
-                sh "mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
+                sh "[ -d "api" ] && mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
                 sh "cp -r spec/target/generated-docs/* /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}"
-                sh "cp -r api/target/apidocs/* /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
+                sh "[ -d "api" ] && cp -r api/target/apidocs/* /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
             }
         }
     }


### PR DESCRIPTION
This may not be the most elegant solution, but we should only be creating the apidocs directory and attempting to copy the apidocs if the component produces them.  In the case of microprofile-bom, we only produce a spec.  No apidocs.

I will not feel the least offended if there is a better way to perform this optional copy.  Just wanted to get the idea out there...  Thanks!