### PR TITLE
Revert "Accept javadocs also in parent"

### DIFF
--- a/buildScripts/release.groovy
+++ b/buildScripts/release.groovy
@@ -33,15 +33,9 @@ pipeline {
                 sh "mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}"
                 sh "cp -r spec/target/generated-docs/* /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}"
                 script {
-                    def apidocsDir = null
-                    if (fileExists('api/target/apidocs')) {
-                        apidocsDir = 'api/target/apidocs'
-                    } else if (fileExists('target/apidocs')) {
-                        apidocsDir = 'target/apidocs'
-                    }
-                    if (apidocsDir != null) {
+                    if (fileExists('api')) {
                         sh "mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
-                        sh "cp -r ${apidocsDir}/* /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
+                        sh "cp -r api/target/apidocs/* /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
                     }
                 }
             }


### PR DESCRIPTION
Reverts eclipse/microprofile-parent#11.  This was accidentally committed before 2.0.1 was finalized...  Have to revert...