### PR TITLE
Add MicroProfile Concurrency to modules list

### DIFF
--- a/buildScripts/release.groovy
+++ b/buildScripts/release.groovy
@@ -1,4 +1,4 @@
-def modules = ['microprofile','microprofile-bom','microprofile-config','microprofile-fault-tolerance',
+def modules = ['microprofile','microprofile-bom','microprofile-concurrency','microprofile-config','microprofile-fault-tolerance',
 	'microprofile-health','microprofile-jwt-auth','microprofile-metrics',
 	'microprofile-open-api','microprofile-opentracing','microprofile-rest-client',
 	'microprofile-reactive-streams-operators', 'microprofile-reactive-messaging']


### PR DESCRIPTION
Add MicroProfile Concurrency so that we can create a release candidate driver per these instructions:
https://wiki.eclipse.org/MicroProfile/SpecRelease/Release