### PR TITLE
Update modules list per rename of MP Concurrency spec

### DIFF
--- a/buildScripts/release.groovy
+++ b/buildScripts/release.groovy
@@ -1,4 +1,4 @@
-def modules = ['microprofile','microprofile-bom','microprofile-concurrency','microprofile-config','microprofile-fault-tolerance',
+def modules = ['microprofile','microprofile-bom','microprofile-config','microprofile-context-propagation','microprofile-fault-tolerance',
 	'microprofile-health','microprofile-jwt-auth','microprofile-metrics',
 	'microprofile-open-api','microprofile-opentracing','microprofile-rest-client',
 	'microprofile-reactive-streams-operators', 'microprofile-reactive-messaging']


### PR DESCRIPTION
Very shortly after I put in the change to add microprofile-concurrency to the modules list, a proposal was made to rename the specification to MicroProfile Context Propagation.  Thus, the modules list again needs an update, switching from microprofile-concurrency to microprofile-context-propagation