### PR TITLE
Add MicroProfile LRA to modules list

### DIFF
--- a/buildScripts/release.groovy
+++ b/buildScripts/release.groovy
@@ -1,7 +1,7 @@
 def modules = ['microprofile','microprofile-bom','microprofile-config','microprofile-context-propagation','microprofile-fault-tolerance',
 	'microprofile-health','microprofile-jwt-auth','microprofile-metrics',
 	'microprofile-open-api','microprofile-opentracing','microprofile-rest-client',
-	'microprofile-reactive-streams-operators', 'microprofile-reactive-messaging']
+	'microprofile-reactive-streams-operators', 'microprofile-reactive-messaging', 'microprofile-lra']
 def moduleString = modules.join('\n')
 pipeline {
     agent any


### PR DESCRIPTION
Signed-off-by: Michael Musgrove <mmusgrov@redhat.com>

Add MicroProfile LRA so that we can create a release candidate driver per these instructions:
https://wiki.eclipse.org/MicroProfile/SpecRelease/Release