### PR TITLE
Jiro migration

### DIFF
--- a/buildScripts/release.groovy
+++ b/buildScripts/release.groovy
@@ -31,20 +31,20 @@ pipeline {
         }
         stage("Copy Specs") {
             steps {
-				sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
-					sh '''
-						ssh genie.microprofile@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}
-						scp -r spec/target/generated-docs/* genie.microprofile@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}
-					'''
-                	script {
-                    	if (fileExists('api')) {
-							sh '''
-								ssh genie.microprofile@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs
-								scp -r api/target/apidocs/* genie.microprofile@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs
-							'''
-                    	}
-                	}
-				}
+                sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
+                    sh '''
+                        ssh genie.microprofile@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}
+                        scp -r spec/target/generated-docs/* genie.microprofile@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}
+                    '''
+                    script {
+                        if (fileExists('api')) {
+                            sh '''
+                                ssh genie.microprofile@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs
+                                scp -r api/target/apidocs/* genie.microprofile@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs
+                            '''
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Due to the JIRO migration (https://bugs.eclipse.org/bugs/show_bug.cgi?id=549976), we needed a couple of updates to our build script.

- Change location of the maven settings file
- Use SSH for copying artifacts to eclipse.download.org