### PR TITLE
Added double-quotes to 'sh' command

### DIFF
--- a/buildScripts/release.groovy
+++ b/buildScripts/release.groovy
@@ -35,7 +35,7 @@ pipeline {
                         git config --global user.email "microprofile-bot@eclipse.org"
                         git config --global user.name "Eclipse MicroProfile bot"
                     '''
-                    sh 'mvn -s /home/jenkins/.m2/settings.xml release:prepare release:perform -B -Dtag=${params.tag} -DdevelopmentVersion=${params.snapshotVersion} -DreleaseVersion=${params.releaseVersion} -Drevremark=${params.revremark}'
+                    sh "mvn -s /home/jenkins/.m2/settings.xml release:prepare release:perform -B -Dtag=${params.tag} -DdevelopmentVersion=${params.snapshotVersion} -DreleaseVersion=${params.releaseVersion} -Drevremark=${params.revremark}"
                 }
             }
         }


### PR DESCRIPTION
It works on [stackoverflow](https://stackoverflow.com/questions/37219348/jenkins-pipeline-sh-bad-substitution). What could go wrong?