### PR TITLE
use alt syntax for script to allow param substitution

### DIFF
--- a/buildScripts/release.groovy
+++ b/buildScripts/release.groovy
@@ -42,16 +42,12 @@ pipeline {
         stage("Copy Specs") {
             steps {
                 sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
-                    sh '''
-                        ssh genie.microprofile@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}
-                        scp -r spec/target/generated-docs/* genie.microprofile@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}
-                    '''
+                    sh "ssh genie.microprofile@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}"
+                    sh "scp -r spec/target/generated-docs/* genie.microprofile@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}"
                     script {
                         if (fileExists('api')) {
-                            sh '''
-                                ssh genie.microprofile@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs
-                                scp -r api/target/apidocs/* genie.microprofile@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs
-                            '''
+                            sh "ssh genie.microprofile@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
+                            sh "scp -r api/target/apidocs/* genie.microprofile@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/microprofile/${params.module}-${params.releaseVersion}/apidocs"
                         }
                     }
                 }


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Use alternate syntax for scripting to allow for parameter substitution.  Cross your fingers...