### PR TITLE
Test dependencies only for the TCK module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,60 @@
-[![License](https://img.shields.io/github/license/smallrye/smallrye-config.svg)](http://www.apache.org/licenses/LICENSE-2.0)
-[![Maven](https://img.shields.io/maven-central/v/org.eclipse.microprofile/microprofile-parent?color=green)](https://search.maven.org/artifact/org.eclipse.microprofile/build-tools)
+
 
 # MicroProfile Parent Repository
 
-This is MicroProfile Parent repository, for the top level parent of MicroProfile specifications.  It stores common pom configuration for all modules.
+The MicroProfile Parent POM provides the required configuration and behavior for all MicroProfile Projects.
+
+## How to use the MicroProfile Parent?
+
+Each MicroProfile project specification expects to follow the folder structure:
+
+- api
+- spec
+- tck
+
+In the project root POM, use the MicroProfile Parent POM:
+
+```xml
+<parent>
+    <groupId>org.eclipse.microprofile</groupId>
+    <artifactId>microprofile-parent</artifactId>
+    <version>${version}</version>
+</parent>
+```
+
+The MicroProfile Parent POM provides the following capabilities:
+
+- Code Quality Checks, including LICENSE headers in source files, code formatting, imports, and sort optimization and 
+Checkstyle validation. Always on by default, can be disabled with `-DskipChecks`
+
+- Automatically generate the source jars
+
+- Automatically generate the Javadocs. Always on by default, can be skipped with `-DskipDocs`
+
+- Automatically generate `pdf` and `html` files from the `src/main/asciidoc` folder.
+
+- Apply the BND configuration if a `bnd.bnd` exists in the root project.
+
+- Handle the required LICENSES to be included in the binaries during development and when performing a release.
+  - The `tck` module requires an empty `tck` file in `src/main/resources/META-INF/`
+  - The argument `-Drelease.revision=Final`, replaces the Apache Licenses with Eclipse Foundation Licenses required for 
+  the final binaries
+
+A MicroProfile BOM TCK is also available to align the testing dependencies for the TCK Modules:
+
+```xml
+  <dependencyManagement>
+      <dependencies>
+          <dependency>
+              <groupId>org.eclipse.microprofile</groupId>
+              <artifactId>microprofile-tck-bom</artifactId>
+              <version>${version}</version>
+              <type>pom</type>
+              <scope>import</scope>
+          </dependency>
+      </dependencies>
+  </dependencyManagement>
+```
+
+The `dependencyManagement` section should be placed in the `tck` POM, to avoid leaking test dependencies to other 
+modules.

--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,6 @@
         <version.jakarta.ws-rs>3.0.0</version.jakarta.ws-rs>
         <version.jakarta.jsonp>2.0.0</version.jakarta.jsonp>
         <version.jakarta.jsonb>2.0.0</version.jakarta.jsonb>
-        <!-- Dependencies - Test -->
-        <version.testng>7.4.0</version.testng> <!-- aligns with Arquillian TestNG version -->
-        <version.junit>4.13.1</version.junit>
-        <version.hamcrest>1.3</version.hamcrest>
-        <version.arquillian>1.7.0.Alpha9</version.arquillian>
 
         <!-- Plugins -->
         <version.microprofile.build-tools>1.1</version.microprofile.build-tools>
@@ -179,33 +174,6 @@
                 <artifactId>jakarta.json.bind-api</artifactId>
                 <version>${version.jakarta.jsonb}</version>
                 <scope>provided</scope>
-            </dependency>
-
-            <!-- Test Dependencies -->
-            <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>${version.testng}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${version.junit}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
-                <version>${version.hamcrest}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>${version.arquillian}</version>
-                <scope>import</scope>
-                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -935,7 +903,7 @@
 
         <!-- Add a tck empty marked file, so this is only executed in the TCK module -->
         <profile>
-            <id>tck</id>
+            <id>tck-licenses</id>
             <activation>
                 <property>
                     <name>release.revision</name>
@@ -1118,4 +1086,8 @@
             </properties>
         </profile>
     </profiles>
+
+    <modules>
+        <module>tck-bom</module>
+    </modules>
 </project>

--- a/tck-bom/pom.xml
+++ b/tck-bom/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017, 2022 Contributors to the Eclipse Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.microprofile</groupId>
+        <artifactId>microprofile-parent</artifactId>
+        <version>2.6-SNAPSHOT</version>
+    </parent>
+
+    <packaging>pom</packaging>
+    <artifactId>microprofile-tck-bom</artifactId>
+    <name>MicroProfile TCK BOM</name>
+    <description>MicroProfile TCK BOM</description>
+
+    <properties>
+        <!-- Dependencies - Test -->
+        <version.testng>7.4.0</version.testng> <!-- aligns with Arquillian TestNG version -->
+        <version.junit>4.13.1</version.junit>
+        <version.hamcrest>1.3</version.hamcrest>
+        <version.arquillian>1.7.0.Alpha9</version.arquillian>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Test Dependencies -->
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${version.testng}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${version.junit}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-all</artifactId>
+                <version>${version.hamcrest}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${version.arquillian}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>


### PR DESCRIPTION
This will prevent the resolution of the testing dependencies for the API jars.