### PR TITLE
Jakarta ee 10 alignement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,11 +38,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <!-- Dependencies - Jakarta -->
-        <version.jakarta.annotation>2.0.0</version.jakarta.annotation>
-        <version.jakarta.cdi>3.0.0</version.jakarta.cdi>
-        <version.jakarta.ws-rs>3.0.0</version.jakarta.ws-rs>
-        <version.jakarta.jsonp>2.0.0</version.jakarta.jsonp>
-        <version.jakarta.jsonb>2.0.0</version.jakarta.jsonb>
+        <version.jakartaee.coreprofile>10.0.0</version.jakartaee.coreprofile>
 
         <!-- Plugins -->
         <version.microprofile.build-tools>1.1</version.microprofile.build-tools>
@@ -132,47 +128,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>jakarta.annotation</groupId>
-                <artifactId>jakarta.annotation-api</artifactId>
-                <version>${version.jakarta.annotation}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>jakarta.enterprise</groupId>
-                <artifactId>jakarta.enterprise.cdi-api</artifactId>
-                <version>${version.jakarta.cdi}</version>
-                <scope>provided</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>jakarta.el</groupId>
-                        <artifactId>jakarta.el-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>jakarta.ejb</groupId>
-                        <artifactId>jakarta.ejb-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>jakarta.ws.rs</groupId>
-                <artifactId>jakarta.ws.rs-api</artifactId>
-                <version>${version.jakarta.ws-rs}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>jakarta.json</groupId>
-                <artifactId>jakarta.json-api</artifactId>
-                <version>${version.jakarta.jsonp}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>jakarta.json.bind</groupId>
-                <artifactId>jakarta.json.bind-api</artifactId>
-                <version>${version.jakarta.jsonb}</version>
+               <groupId>jakarta.platform</groupId>
+                <artifactId>jakarta.jakartaee-core-api</artifactId>
+                <version>${version.jakartaee.coreprofile}</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.eclipse.microprofile</groupId>
     <artifactId>microprofile-parent</artifactId>
-    <version>2.7-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>MicroProfile Parent POM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Compiler -->
-        <java.version>1.8</java.version>
-        <java.release>8</java.release>
+        <java.version>11</java.version>
+        <java.release>11</java.release>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 

--- a/tck-bom/pom.xml
+++ b/tck-bom/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile-parent</artifactId>
-        <version>2.7-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tck-bom/pom.xml
+++ b/tck-bom/pom.xml
@@ -33,7 +33,7 @@
         <version.testng>7.4.0</version.testng> <!-- aligns with Arquillian TestNG version -->
         <version.junit>4.13.1</version.junit>
         <version.hamcrest>1.3</version.hamcrest>
-        <version.arquillian>1.7.0.Alpha9</version.arquillian>
+        <version.arquillian>1.7.0.Alpha10</version.arquillian>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Since the minimum Java source/binary for Jakarta EE 10 Core Profile is 11, we need to update the parent pom to use Java 11 as the compilation and binary level.