### PR TITLE
Asciidoctor version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,11 @@
         <version.plugin.rat>0.15</version.plugin.rat>
         <version.plugin.bnd>6.4.0</version.plugin.bnd>
         
-        <!-- AsciiDoctor support versions -->
-        <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>2.3.4</asciidoctorj.pdf.version>
+        <!-- Asciidoctor support versions -->
+        <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.5.10</asciidoctorj.version>
+        <asciidoctorj.pdf.version>2.3.7</asciidoctorj.pdf.version>
+        <jruby.version>9.4.2.0</jruby.version>
         
         <version.plugin.copy.rename>1.0.1</version.plugin.copy.rename>
         <version.plugin.release>3.0.0-M7</version.plugin.release>
@@ -412,6 +414,25 @@
                     <groupId>org.asciidoctor</groupId>
                     <artifactId>asciidoctor-maven-plugin</artifactId>
                     <version>${asciidoctor.maven.plugin.version}</version>
+                    <dependencies>
+                    <!-- Comment this section to use the default jruby artifact provided by the plugin -->
+                    <dependency>
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby</artifactId>
+                        <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj</artifactId>
+                        <version>${asciidoctorj.version}</version>
+                    </dependency>
+                        <dependency>
+                            <groupId>org.asciidoctor</groupId>
+                            <artifactId>asciidoctorj-pdf</artifactId>
+                            <version>${asciidoctorj.pdf.version}</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
                         <sourceDocumentName>${project.artifactId}.asciidoc</sourceDocumentName>
                         <attributes>
@@ -446,13 +467,6 @@
                             </configuration>
                         </execution>
                     </executions>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.asciidoctor</groupId>
-                            <artifactId>asciidoctorj-pdf</artifactId>
-                            <version>${asciidoctorj.pdf.version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
 
                 <!-- Release -->

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,11 @@
         <version.plugin.checkstyle>3.2.1</version.plugin.checkstyle>
         <version.plugin.rat>0.15</version.plugin.rat>
         <version.plugin.bnd>6.4.0</version.plugin.bnd>
-        <version.plugin.asciidoctor>2.2.2</version.plugin.asciidoctor>
-        <version.plugin.asciidoctor.pdf>2.3.4</version.plugin.asciidoctor.pdf>
+        
+        <!-- AsciiDoctor support versions -->
+        <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
+        <asciidoctorj.pdf.version>2.3.4</asciidoctorj.pdf.version>
+        
         <version.plugin.copy.rename>1.0.1</version.plugin.copy.rename>
         <version.plugin.release>3.0.0-M7</version.plugin.release>
         <version.plugin.gpg>3.0.1</version.plugin.gpg>
@@ -408,7 +411,7 @@
                 <plugin>
                     <groupId>org.asciidoctor</groupId>
                     <artifactId>asciidoctor-maven-plugin</artifactId>
-                    <version>${version.plugin.asciidoctor}</version>
+                    <version>${asciidoctor.maven.plugin.version}</version>
                     <configuration>
                         <sourceDocumentName>${project.artifactId}.asciidoc</sourceDocumentName>
                         <attributes>
@@ -447,7 +450,7 @@
                         <dependency>
                             <groupId>org.asciidoctor</groupId>
                             <artifactId>asciidoctorj-pdf</artifactId>
-                            <version>${version.plugin.asciidoctor.pdf}</version>
+                            <version>${asciidoctorj.pdf.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
Updates Asciidoctor Maven Plugin and it's dependencies to fix remaining CVE-2022-24823.

It also renamed the existing related version properties to follow Maven conventions, clarification and to align with the MicroProfile (platform) project configuration.
NOTE: I checked usage of this versions in issue #63 before: There is no external use at that time, only internal one in this repo - so it can be changed without breaking something.

This is a fix for the remaining CVE only, extracted from PR #66, that will be updated when this fix is done. MicroProfile (platform) got an similar fix [here](https://github.com/eclipse/microprofile/pull/316) already and will get a separate PR to align versions there too.