### PR TITLE
Update plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,11 @@
         <maven.compiler.release>${java.release}</maven.compiler.release>
 
         <!-- Dependencies - Jakarta -->
-        <version.jakartaee.coreprofile>10.0.0</version.jakartaee.coreprofile>
-
+         <version.jakarta.jsonp>2.1.0</version.jakarta.jsonp>
+         <version.jakarta.jsonb>3.0.0</version.jakarta.jsonb>
+         <version.jakarta.annotation>2.1.1</version.jakarta.annotation>
+         <version.jakarta.cdi>4.0.1</version.jakarta.cdi>
+         <version.jakarta.ws-rs>3.1.0</version.jakarta.ws-rs>
         <!-- Plugins -->
         <version.microprofile.build-tools>1.1</version.microprofile.build-tools>
 
@@ -127,9 +130,47 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-               <groupId>jakarta.platform</groupId>
-                <artifactId>jakarta.jakartaee-core-api</artifactId>
-                <version>${version.jakartaee.coreprofile}</version>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${version.jakarta.annotation}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${version.jakarta.cdi}</version>
+                <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>jakarta.el</groupId>
+                        <artifactId>jakarta.el-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.ejb</groupId>
+                        <artifactId>jakarta.ejb-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${version.jakarta.ws-rs}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
+                <version>${version.jakarta.jsonp}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.json.bind</groupId>
+                <artifactId>jakarta.json.bind-api</artifactId>
+                <version>${version.jakarta.jsonb}</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>

--- a/tck-bom/pom.xml
+++ b/tck-bom/pom.xml
@@ -31,11 +31,11 @@
     <properties>
         <!-- Dependencies - Test -->
         <!-- Aligns with Arquillian TestNG version -->
-        <version.testng>7.5</version.testng>
+        <version.testng>7.8.0</version.testng>
         <!-- Aligns with Arquillian JUnit 4 version -->
         <version.junit>4.13.2</version.junit>
         <version.hamcrest>1.3</version.hamcrest>
-        <version.arquillian>1.7.0.Alpha14</version.arquillian>
+        <version.arquillian>1.7.0.Final</version.arquillian>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Update to the TestNG 7.8.0 which has the latest CVE fixes as well as consume the latest Arquillian version. In the past, the dependency only specifies Jakarta Core Profile 10.0. Due to some feedback, the dependencies on the individual Jakarta EE specifications are preferred. 