### PR TITLE
Fix cyclonedx version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1107,6 +1107,7 @@
                         <plugin>
                             <groupId>org.cyclonedx</groupId>
                             <artifactId>cyclonedx-maven-plugin</artifactId>
+                            <version>${version.plugin.cyclonedx}</version>
                             <configuration>
                                 <schemaVersion>1.4</schemaVersion>
                                 <projectType>library</projectType>


### PR DESCRIPTION
Reference the cyclonedx version property where we include the plugin.

Without this, the latest version (2.8.0) is used instead of the desired version (2.7.9), as seen in the build output:

```
[INFO] --- cyclonedx:2.8.0:makeAggregateBom (default) @ microprofile-parent ---
```

Also this warning is emitted
```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.eclipse.microprofile:microprofile-tck-bom:pom:3.3-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.cyclonedx:cyclonedx-maven-plugin is missing. @ org.eclipse.microprofile:microprofile-parent:3.3-SNAPSHOT, /home/andrew/git/microprofile-parent/pom.xml, line 1107, column 33
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.eclipse.microprofile:microprofile-parent:pom:3.3-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.cyclonedx:cyclonedx-maven-plugin is missing. @ line 1107, column 33
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

