### PR TITLE
[3.x] Add sources with jar-no-fork to fix release builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -651,7 +651,7 @@
                             <execution>
                                 <id>attach-sources</id>
                                 <goals>
-                                    <goal>jar</goal>
+                                    <goal>jar-no-fork</goal>
                                 </goals>
                             </execution>
                         </executions>
@@ -676,7 +676,7 @@
                             <execution>
                                 <id>attach-sources-test</id>
                                 <goals>
-                                    <goal>test-jar</goal>
+                                    <goal>test-jar-no-fork</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
As #89 but for the main branch.

Previously, the `sources` profile added the [`jar` goal][jar] and the `release` profile added the [`jar-no-fork` goal][jar-nf] to add the sources jar. When both profiles are enabled (as happens when doing a release in a project with source code) it runs both goals and tries to create the sources jar twice.

This previously was reported as a warning when the same artifact was attached twice, but is an error since version 3.3.0 of the source plugin. [MSOURCES-121][issue]

This error can be reproduced locally by running `mvn verify -Prelease` (as happens during `release:prepare`)

As far as I can see, `jar-no-fork` is the goal we should be using in the pom. The `jar` goal repeats the `generate-sources` phase, which is helpful if you run it from the command line, but unnecessary when you're running it as part of a build which has already run `generate-sources`.

I'm unsure if there's any need to keep the goal in the `release` profile. If there are sources then the `sources` profile should be active and if there are no sources we don't need to create a sources jar anyway. However, I've left it in place in case there's something I've overlooked.

Note: requesting two phases on the command line at once such as `mvn package install` or `mvn install deploy` will cause most of the goals configured to run twice, including the source-plugin goals, so even with this change, you will still get the error if you do this.

[jar]: https://maven.apache.org/plugins/maven-source-plugin/jar-mojo.html
[jar-nf]: https://maven.apache.org/plugins/maven-source-plugin/jar-no-fork-mojo.html
[issue]: https://issues.apache.org/jira/browse/MSOURCES-121