### PR TITLE
[2.x] Use efsl-1.1 for final releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1075,8 +1075,8 @@
                 </property>
             </activation>
             <properties>
-                <spec.license>efsl-1.0</spec.license>
-                <tck.license>eftckl-1.0</tck.license>
+                <spec.license>efsl-1.1</spec.license>
+                <tck.license>eftckl-1.1</tck.license>
             </properties>
         </profile>
         


### PR DESCRIPTION
This controls the license files referenced in the Javadoc footer.

A similar change on the `main` branch was included in #80