### PR TITLE
Remove provided scope from dependencyManagement section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,14 +138,12 @@
                 <groupId>jakarta.annotation</groupId>
                 <artifactId>jakarta.annotation-api</artifactId>
                 <version>${version.jakarta.annotation}</version>
-                <scope>provided</scope>
             </dependency>
 
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.cdi-api</artifactId>
                 <version>${version.jakarta.cdi}</version>
-                <scope>provided</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>jakarta.el</groupId>
@@ -162,21 +160,18 @@
                 <groupId>jakarta.ws.rs</groupId>
                 <artifactId>jakarta.ws.rs-api</artifactId>
                 <version>${version.jakarta.ws-rs}</version>
-                <scope>provided</scope>
             </dependency>
 
             <dependency>
                 <groupId>jakarta.json</groupId>
                 <artifactId>jakarta.json-api</artifactId>
                 <version>${version.jakarta.jsonp}</version>
-                <scope>provided</scope>
             </dependency>
 
             <dependency>
                 <groupId>jakarta.json.bind</groupId>
                 <artifactId>jakarta.json.bind-api</artifactId>
                 <version>${version.jakarta.jsonb}</version>
-                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Using the scope in the dependencyManagement section forces the scope in child projects unless the scope is explicitly set
